### PR TITLE
Added support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,11 @@ Carthage/Build
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-# 
+#
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
 Pods/
+
+# SPM
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MemfaultCloud",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(name: "MemfaultCloud", targets: ["MemfaultCloud"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "MemfaultCloud", dependencies: [], path: "MemfaultCloud/Classes")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ### Adding MemfaultCloud to your project
 
+#### Swift Package Manager
+
+Add this line to your dependencies list in your Package.swift:
+
+```
+.package(name: "MemfaultCloud", url: "https://github.com/memfault/memfault-ios-cloud.git", from: "2.2.0"),
+```
+
 #### CocoaPods
 
 In case you are using CocoaPods, you can add `MemfaultCloud` as a dependency to


### PR DESCRIPTION
This PR adds support for installing this library via Swift Package Manager in addition to CocoaPods. Note that I just picked `2.2` as the first version which might support this in my README change, but that'll need to be updated per your preference.