### PR TITLE
Remove package header

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,3 @@
-///
-/// Copyright (c) Memfault, Inc.
-/// See LICENSE for details
-///
-
 // swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription


### PR DESCRIPTION
The `// swift-tools-version: 5.5` line must be at the top of the file for SPM to be happy. Alternatively the license could be moved below.